### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/filepreviews.svg)](http://badge.fury.io/rb/filepreviews)
 [![Dependency Status](https://gemnasium.com/jonahoffline/filepreviews-ruby.svg)](https://gemnasium.com/jonahoffline/filepreviews-ruby)
 [![Code Climate](https://codeclimate.com/github/jonahoffline/filepreviews-ruby.png)](https://codeclimate.com/github/jonahoffline/filepreviews-ruby)
+[![Inline docs](http://inch-pages.github.io/github/jonahoffline/filepreviews-ruby.png)](http://inch-pages.github.io/github/jonahoffline/filepreviews-ruby)
 
 This is the ruby client library for the **Demo API** of [FilePreviews.io](http://filepreviews.io) service. A lot more to come very soon.
 


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/jonahoffline/filepreviews-ruby.png)

Your status page for this project is http://inch-pages.github.io/github/jonahoffline/filepreviews-ruby

Thanks for giving this a shot!
