### PR TITLE
Allow users to specify "data" and "uploader" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ conf = {
     # supported: 'jpg', 'jpeg', 'png'
     format: 'jpg',
 
+    # Arbitrary key/value pairs that are returned in the "user_data" field in response
+    data: {
+      uuid: 'database_identifier'
+    },
+
+    # Support for specifying custom headers when the preview is placed in storage container
+    uploader: {
+      destination: 'directory/name',
+      headers: {} # common request headers to S3 bucket for instance
+    },
+
     # supported: '1', '1-3', '1,3,5', '1-3', 'all'
     pages: '1-3'
   }

--- a/lib/filepreviews/http.rb
+++ b/lib/filepreviews/http.rb
@@ -64,6 +64,8 @@ module Filepreviews
       request = process_params(params)
       request.store(:sizes, [extract_size(params.size)]) if params.size
       request.store(:format, params.format) if params.format
+      request.store(:data, params.data) if params.data
+      request.store(:uploader, params.uploader) if params.uploader
       request
     end
 

--- a/spec/filepreviews/http_spec.rb
+++ b/spec/filepreviews/http_spec.rb
@@ -48,4 +48,43 @@ describe Filepreviews::HTTP do
       end
     end
   end
+
+  describe '.prepare_request' do
+    let(:params) { OpenStruct.new(options) }
+    let(:request) { http.prepare_request(params) }
+
+    context 'when custom :data is provided' do
+      let(:options) do
+        {
+          url: 'testing.com',
+          uploader: { header: 'storage' },
+          data: { custom: :value }
+        }
+      end
+
+      it 'includes the :data hash without changes' do
+        expect(request).to include(data: { custom: :value })
+      end
+
+      it 'includes the :uploader hash without changes' do
+        expect(request).to include(uploader: { header: 'storage' })
+      end
+    end
+
+    context 'when no custom :data is provided' do
+      let(:options) do
+        {
+          url: 'testing.com'
+        }
+      end
+
+      it 'does not include the :data key' do
+        expect(request).not_to have_key(:data)
+      end
+
+      it 'does not include the :uploader key' do
+        expect(request).not_to have_key(:uploader)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `data` and `uploader` attributes were being skipped entirely, and is a valid API option according to the API docs.

This fixes issue #13.