### PR TITLE
Should Fix: #18

### DIFF
--- a/lib/filepreviews/utils.rb
+++ b/lib/filepreviews/utils.rb
@@ -13,7 +13,7 @@ module Filepreviews
     # @param metadata [Array] image formats
     # @return [String] metadata url parameters
     def extract_metadata(metadata)
-      metadata.join(',')
+      metadata.to_a
     end
 
     # Validates page parameters

--- a/lib/filepreviews/utils.rb
+++ b/lib/filepreviews/utils.rb
@@ -42,7 +42,7 @@ module Filepreviews
       parameters = { url: CGI.unescape(params.url) }
 
       if params.metadata
-        parameters[:metadata] = [extract_metadata(params.metadata)]
+        parameters[:metadata] = extract_metadata(params.metadata)
       end
 
       parameters

--- a/spec/filepreviews/filepreviews_spec.rb
+++ b/spec/filepreviews/filepreviews_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Filepreviews do
   let(:file_previews) { Filepreviews }
-  let(:sample_img) { 'http://pixelhipsters.com/images/pixelhipster_cat.png' }
+  let(:sample_img) { 'https://images.pexels.com/photos/876441/pexels-photo-876441.jpeg' }
 
   it 'keeps it real, you feels me dawg?' do
     expect(true).to eq(true)
@@ -30,14 +30,31 @@ describe Filepreviews do
     end
 
     context 'when used with an api key' do
-      it 'returns a Filepreviews::Response instance' do
+      before(:each) do
         Filepreviews.api_key = ENV['FILEPREVIEWS_API_KEY']
         Filepreviews.secret_key = ENV['FILEPREVIEWS_SECRET_KEY']
+      end
+
+      it 'returns a Filepreviews::Response instance' do
         response = file_previews.generate(sample_img)
 
         expect(response.url).to_not be_nil
         expect(response.id).to_not be_nil
         expect(response).to be_an_instance_of(Filepreviews::Response)
+      end
+
+      context 'with additional metadata' do
+        it 'returns a Filepreviews::Response instance' do
+          response = file_previews.generate(sample_img, {
+            options: {
+              metadata: [ 'ocr', 'psd', 'exif', 'sketch', 'webpage', 'checksum', 'multimedia' ]
+            }
+          })
+
+          expect(response.url).to_not be_nil
+          expect(response.id).to_not be_nil
+          expect(response).to be_an_instance_of(Filepreviews::Response)
+        end
       end
     end
 

--- a/spec/filepreviews/utils_spec.rb
+++ b/spec/filepreviews/utils_spec.rb
@@ -25,6 +25,16 @@ describe Filepreviews::Utils do
     end
   end
 
+  describe '.extract_metadata' do
+    it 'returns one metadata entry as an array' do
+      expect(Kawaii.new.extract_metadata([:psd])).to eq([:psd])
+    end
+
+    it 'returns multipe metadata entries as an array' do
+      expect(Kawaii.new.extract_metadata([:psd, :ocr])).to eq([:psd, :ocr])
+    end
+  end
+
   describe '.validate_pages' do
     context 'when called with range parameters (1-3)' do
       it 'validates page parameters' do


### PR DESCRIPTION
`to_a` is just in case someone passes a non-array but convertable value.