### PR TITLE
Allow callback_url in `generate` options

### DIFF
--- a/lib/filepreviews/http.rb
+++ b/lib/filepreviews/http.rb
@@ -67,6 +67,7 @@ module Filepreviews
       request.store(:data, params.data) if params.data
       request.store(:uploader, params.uploader) if params.uploader
       request.store(:pages, params.pages) if params.pages
+      request.store(:callback_url, params.callback_url) if params.callback_url
       request
     end
 


### PR DESCRIPTION
The FilePreviews API lets you specify a callback url when generating a preview. This PR allows the gem to pass on such a callback url