### PR TITLE
Fix bundler and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ language: ruby
 os: linux
 dist: xenial
 rvm:
-- 2.7.1
-- 2.4.1
-- 2.3.3
-- 2.2.6
-- 2.1.1
-- 2.0.0
+  - ruby-head
+  - truffleruby
+  - truffleruby-20.1.0
+  - 2.7.1
+  - 2.6.6
+  - 2.5.8
+  - 2.4.10
 script: bundle exec rake test
 env:
   global:
   - secure: ksz/xSq5EkiWQfclYHh5gj32IjqH5uTXacYqFGZdpZWPtkxGscSVeBzAvGtY9IQddkEuobVEW8TBqPo2rZ+7sT6ZfLQOuNM9Vtw5jDbAifyHLivZ5/acnW7m5BcmkxttKrel4DfRexzvGW6SAweE+fC07BLfPjzyKoIyjKnV4Y8=
   - secure: lYcTOY21MNhFAvd3mCNj0CBoMJYMLGy+PsNcuLvhNcQHw/+ulkzQITJFo9IaAOl8TXv+ETAfay0eXfzVC8hE8DTeq3QovdocciMa+otCpVQWRzDwfc+mfUqutdgn96CjAmkvGYHwkDf/X4LBRaDhI2beKeaGO/BGQZw+NMEBFzo=
+jobs:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
-sudo: false
+os: linux
+dist: xenial
 rvm:
 - 2.7.1
 - 2.4.1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # FilePreviews.io (Ruby client)
 [![Gem Version](https://badge.fury.io/rb/filepreviews.svg)](https://badge.fury.io/rb/filepreviews)
 [![Build Status](https://travis-ci.org/jonahoffline/filepreviews-ruby.svg?branch=master)](https://travis-ci.org/jonahoffline/filepreviews-ruby)
-[![security](https://hakiri.io/github/jonahoffline/filepreviews-ruby/master.svg)](https://hakiri.io/github/jonahoffline/filepreviews-ruby/master)
 [![Maintainability](https://api.codeclimate.com/v1/badges/da1cc5ca8fbbbf1ae3a9/maintainability)](https://codeclimate.com/github/jonahoffline/filepreviews-ruby/maintainability)
 [![Inline docs](http://inch-ci.org/github/jonahoffline/filepreviews-ruby.png)](http://inch-ci.org/github/jonahoffline/filepreviews-ruby)
 
@@ -46,7 +45,7 @@ Simpler style:
 require 'filepreviews'
 
 Filepreviews.api_key = 'YOUR_API_KEY'
-Filepreviews.config.secret_key = 'YOUR_SECRET_KEY'
+Filepreviews.secret_key = 'YOUR_SECRET_KEY'
 ```
 
 ### Basic Example Code

--- a/filepreviews.gemspec
+++ b/filepreviews.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/filepreviews.gemspec
+++ b/filepreviews.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 


### PR DESCRIPTION
- [x] Remove bundler from `gemspec` file
- [x] Update README (remove old badge + update examples)

### Travis
- [x] Add TruffleRuby, ruby-head and supported versions:
   - RVM targets: `2.6.6`, `2.5.8`, `2.4.10`, `ruby-head`, `truffleruby`, `truffleruby-20.1.0`
- [x] Remove unsupported versions

##
- [x] Ready